### PR TITLE
Update tutorial example to render custom breadcrumb

### DIFF
--- a/extensions/custom-header/src/Extension.jsx
+++ b/extensions/custom-header/src/Extension.jsx
@@ -1,11 +1,56 @@
-import {Image} from '@shopify/ui-extensions-react/checkout';
+import {
+  BlockStack,
+  Image,
+  InlineLayout,
+  Link,
+  Text,
+  View,
+  useBuyerJourneySteps,
+  useBuyerJourneyActiveStep,
+  useShop,
+} from '@shopify/ui-extensions-react/checkout';
 
 // [START custom-header.render]
 export default function Extension() {
+  const steps = useBuyerJourneySteps();
+  const activeStep = useBuyerJourneyActiveStep();
+  const {storefrontUrl, name} = useShop();
+
+  const activeStepIndex = steps.findIndex(
+    ({handle}) => handle === activeStep?.handle,
+  );
+
   return (
-    // Replace the source with your own image url. Learn more:
+    // Replace the image source with your own image url. Learn more:
     // https://help.shopify.com/en/manual/shopify-admin/productivity-tools/file-uploads
-    <Image source="https://cdn.shopify.com/path/to/image/file_name.png" />
+    <BlockStack spacing="tight">
+      <Image source="https://cdn.shopify.com/path/to/image/file_name.png" />
+      <InlineLayout accessibilityRole="orderedList" spacing="tight">
+        <View
+          accessibilityRole="listItem"
+          inlineAlignment="center"
+          border="base"
+          padding="base"
+          background="base">
+          <Link to={storefrontUrl}>{name}</Link>
+        </View>
+        {steps.map(({label, handle, to}, index) => (
+          <View
+            accessibilityRole="listItem"
+            inlineAlignment="center"
+            key={handle}
+            border="base"
+            padding="base"
+            background={activeStep?.handle === handle ? 'subdued' : 'base'}>
+            {activeStep?.handle === handle || index > activeStepIndex ? (
+              <Text>{label}</Text>
+            ) : (
+              <Link to={to}>{label}</Link>
+            )}
+          </View>
+        ))}
+      </InlineLayout>
+    </BlockStack>
   );
 }
 // [END custom-header.render]

--- a/extensions/custom-header/src/Extension.jsx
+++ b/extensions/custom-header/src/Extension.jsx
@@ -10,8 +10,8 @@ import {
   useShop,
 } from '@shopify/ui-extensions-react/checkout';
 
-// [START custom-header.render]
 export default function Extension() {
+  // [START custom-header.buyer-journey]
   const steps = useBuyerJourneySteps();
   const activeStep = useBuyerJourneyActiveStep();
   const {storefrontUrl, name} = useShop();
@@ -19,7 +19,9 @@ export default function Extension() {
   const activeStepIndex = steps.findIndex(
     ({handle}) => handle === activeStep?.handle,
   );
+  // [END custom-header.buyer-journey]
 
+  // [START custom-header.render]
   return (
     // Replace the image source with your own image url. Learn more:
     // https://help.shopify.com/en/manual/shopify-admin/productivity-tools/file-uploads
@@ -52,5 +54,5 @@ export default function Extension() {
       </InlineLayout>
     </BlockStack>
   );
+  // [END custom-header.render]
 }
-// [END custom-header.render]


### PR DESCRIPTION
Updating tutorial example to use new useBuyerJourneySteps, useBuyerJourneyActiveStep hooks to render custom breadcrumbs

<img width="1166" alt="Screenshot 2024-03-25 at 3 39 46 PM" src="https://github.com/Shopify/example-checkout--custom-header--react/assets/82546995/c9cc3eee-da3c-49f4-bbbe-c58face87059">
